### PR TITLE
Set up CI/CD with GitHub Actions and itch.io's Butler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,218 @@
+name: Build Executables
+on: [push]
+jobs:
+
+  tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - name: Install dependencies
+      shell: bash
+      run: sudo apt-get -y install libgl1-mesa-dev xorg-dev libasound2-dev
+    - name: Run tests
+      shell: bash
+      run: xvfb-run go test -v ./...
+
+  build-win:
+    name: Build Windows binary
+    needs: tests
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - name: Build Windows exe
+      shell: bash
+      run: go build
+    - name: Upload Windows exe
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: magnets-win
+        path: |
+          LICENSE
+          magnets.exe
+
+  build-mac:
+    name: Build MacOS binary
+    needs: tests
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - name: Build Mac exe
+      shell: bash
+      run: go build
+    - name: Tar it up
+      shell: bash
+      run: tar -zcvf magnets-mac.tar.gz magnets LICENSE
+    - name: Upload Mac exe
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: magnets-mac
+        path: magnets-mac.tar.gz
+
+  build-lin:
+    name: Build Linux binary
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - name: Install dependencies
+      shell: bash
+      run: sudo apt-get -y install libgl1-mesa-dev xorg-dev libasound2-dev
+    - name: Build Linux exe
+      shell: bash
+      run: go build -v
+    - name: Tar it up
+      shell: bash
+      run: tar -zcvf magnets-lin.tar.gz magnets LICENSE
+    - name: Upload Linux exe
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: magnets-lin
+        path: magnets-lin.tar.gz
+
+  build-web:
+    name: Build Web binary
+    needs: tests
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+    - name: Build Web binary
+      shell: bash
+      run: GOOS=js GOARCH=wasm go build -v -ldflags "-w -s" -o dist/web/magnets.wasm
+    - name: Copy WASM exec script
+      shell: bash
+      run: cp $(go env GOROOT)/misc/wasm/wasm_exec.js dist/web/.
+    - name: Upload Web build
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: magnets-web
+        path: |
+          dist/web/
+          LICENSE
+
+  upload-bundle:
+    name: Bundle binaries with dev assets
+    runs-on: ubuntu-latest
+    needs: [build-lin, build-mac, build-win]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download Windows binary
+      uses: actions/download-artifact@v2
+      with:
+        name: magnets-win
+    - name: Download Linux binary
+      uses: actions/download-artifact@v2
+      with:
+        name: magnets-lin
+    - name: Download Mac binary
+      uses: actions/download-artifact@v2
+      with:
+        name: magnets-mac
+    - name: Upload beta testing bundle
+      uses: actions/upload-artifact@v2.2.4
+      with:
+        name: magnets-bundle
+        path: |
+          README.md
+          LICENSE
+          magnets-lin.tar.gz
+          magnets-mac.tar.gz
+          magnets.exe
+
+  deploy-win:
+    name: Deploy Windows build to itch.io
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    needs: build-win
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: magnets-win
+    - uses: josephbmanley/butler-publish-itchio-action@master
+      env:
+        BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+        CHANNEL: windows
+        ITCH_GAME: magnets
+        ITCH_USER: xackery
+        PACKAGE: magnets.exe
+        VERSION: ${{github.ref_name}}
+
+  deploy-mac:
+    name: Deploy MacOs build to itch.io
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    needs: build-mac
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: magnets-mac
+    - name: Extract tarball
+      shell: bash
+      run: tar -zxvf magnets-mac.tar.gz
+    - uses: josephbmanley/butler-publish-itchio-action@master
+      env:
+        BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+        CHANNEL: mac
+        ITCH_GAME: magnets
+        ITCH_USER: xackery
+        PACKAGE: magnets
+        VERSION: ${{github.ref_name}}
+
+  deploy-lin:
+    name: Deploy Linux build to itch.io
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    needs: build-lin
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: magnets-lin
+    - name: Extract tarball
+      shell: bash
+      run: tar -zxvf magnets-lin.tar.gz
+    - uses: josephbmanley/butler-publish-itchio-action@master
+      env:
+        BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+        CHANNEL: linux
+        ITCH_GAME: magnets
+        ITCH_USER: xackery
+        PACKAGE: magnets
+        VERSION: ${{github.ref_name}}
+
+  deploy-web:
+    name: Deploy Web build to itch.io
+    if: startsWith(github.event.ref, 'refs/tags/v')
+    needs: build-web
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/download-artifact@v2
+      with:
+        name: magnets-web
+    - uses: josephbmanley/butler-publish-itchio-action@master
+      env:
+        BUTLER_CREDENTIALS: ${{ secrets.BUTLER_CREDENTIALS }}
+        CHANNEL: web
+        ITCH_GAME: magnets
+        ITCH_USER: xackery
+        PACKAGE: dist/web
+        VERSION: ${{github.ref_name}}

--- a/dist/web/index.html
+++ b/dist/web/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<script src="wasm_exec.js"></script>
+<script>
+// Polyfill
+if (!WebAssembly.instantiateStreaming) {
+  WebAssembly.instantiateStreaming = async (resp, importObject) => {
+    const source = await (await resp).arrayBuffer();
+    return await WebAssembly.instantiate(source, importObject);
+  };
+}
+
+const go = new Go();
+WebAssembly.instantiateStreaming(fetch("magnets.wasm"), go.importObject).then(result => {
+  go.run(result.instance);
+});
+</script>


### PR DESCRIPTION
Each push on the master branch triggers artefacts to be built for each platform of Windows, Linux, MacOS, which will be attached to that commit in GitHub.

Versioned tags will trigger a new release with that version on itch.io if the `BUTTLER_CREDENTIALS` secret is set up. For this you can generate a new API key [here](https://itch.io/user/settings/api-keys), and paste it in [here](https://github.com/raa0121/magnet/settings/secrets/actions) with the name `BUTTLER_CREDENTIALS`. Read more about encrypted secrets [here](https://docs.github.com/en/actions/security-guides/encrypted-secrets).

This pull request is based on: https://github.com/sinisterstuf/ebiten-game-template/